### PR TITLE
Add support for featured images

### DIFF
--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -12,6 +12,12 @@ permalink: "/"
 {% for project in collections.projects %}
   {% if project.data.media %}
     {% set block = project.data.media[0] %}
+    {% for mediaBlock in project.data.media %}
+      {# TODO this could probably be improved… #}
+      {% if mediaBlock.featured %}
+        {% set block = project.data.media[loop.index0] %}
+      {% endif %}
+    {% endfor %}
     {% set blockClasses = block.size if block.size else 'md' %}
     <article class="home-block {{ blockClasses }}">
       <a href="{{ project.url }}">


### PR DESCRIPTION
@piperhaywood this does the job but the logic could probably be written better.

Add `featured: true` to a media block and it'll replace the image. 

## TODO
- Not sure what to do if there's more than one featured image – should prob just show the first / last one? Just need to be consistent I guess. 
- Add corresponding docs